### PR TITLE
reset calculator between precedence ambiguity tests

### DIFF
--- a/spec/12_rpn_calculator_spec.rb
+++ b/spec/12_rpn_calculator_spec.rb
@@ -105,6 +105,7 @@ describe RPNCalculator do
     calculator.times
     calculator.value.should == (1+2)*3
 
+    @calculator = RPNCalculator.new
     # 1 2 3 * + => 1 + (2 * 3)
     calculator.push(1)
     calculator.push(2)


### PR DESCRIPTION
The test seems wrong because it includes two tests in one, but does not reset the state of the calculator
(which should be able to accept new operations or pushes, maintaining the previous value in memory).
