### PR TITLE
Refactoring textual representation of specs

### DIFF
--- a/spec/00_hello_spec.rb
+++ b/spec/00_hello_spec.rb
@@ -102,18 +102,20 @@
 
 require "00_hello"
 
-describe "the hello function" do
-  it "says hello" do
-    expect(hello).to eq("Hello!")
-  end
-end
-
-describe "the greet function" do
-  it "says hello to someone" do
-    expect(greet("Alice")).to eq("Hello, Alice!")
+describe "Hello" do
+  describe "#hello" do
+    it "says hello" do
+      expect(hello).to eq("Hello!")
+    end
   end
 
-  it "says hello to someone else" do
-    expect(greet("Bob")).to eq("Hello, Bob!")
+  describe "#greet" do
+    it "says hello to someone" do
+      expect(greet("Alice")).to eq("Hello, Alice!")
+    end
+
+    it "says hello to someone else" do
+      expect(greet("Bob")).to eq("Hello, Bob!")
+    end
   end
 end

--- a/spec/01_temperature_spec.rb
+++ b/spec/01_temperature_spec.rb
@@ -20,7 +20,7 @@
 
 require "01_temperature"
 
-describe "temperature conversion functions" do
+describe "Temperature" do
   describe "#ftoc" do
     it "converts freezing temperature" do
       expect(ftoc(32)).to eq(0)

--- a/spec/02_calculator_spec.rb
+++ b/spec/02_calculator_spec.rb
@@ -37,62 +37,64 @@
 
 require "02_calculator"
 
-describe "add" do
-  it "adds 0 and 0" do
-    expect(add(0, 0)).to eq(0)
+describe "Calculator" do
+  describe "#add" do
+    it "adds 0 and 0" do
+      expect(add(0, 0)).to eq(0)
+    end
+
+    it "adds 2 and 2" do
+      expect(add(2, 2)).to eq(4)
+    end
+
+    it "adds positive numbers" do
+      expect(add(2, 6)).to eq(8)
+    end
   end
 
-  it "adds 2 and 2" do
-    expect(add(2, 2)).to eq(4)
+  describe "#subtract" do
+    it "subtracts numbers" do
+      expect(subtract(10, 4)).to eq(6)
+    end
   end
 
-  it "adds positive numbers" do
-    expect(add(2, 6)).to eq(8)
-  end
-end
+  describe "#sum" do
+    it "computes the sum of an empty array" do
+      expect(sum([])).to eq(0)
+    end
 
-describe "subtract" do
-  it "subtracts numbers" do
-    expect(subtract(10, 4)).to eq(6)
-  end
-end
+    it "computes the sum of an array of one number" do
+      expect(sum([7])).to eq(7)
+    end
 
-describe "sum" do
-  it "computes the sum of an empty array" do
-    expect(sum([])).to eq(0)
-  end
+    it "computes the sum of an array of two numbers" do
+      expect(sum([7, 11])).to eq(18)
+    end
 
-  it "computes the sum of an array of one number" do
-    expect(sum([7])).to eq(7)
+    it "computes the sum of an array of many numbers" do
+      expect(sum([1, 3, 5, 7, 9])).to eq(25)
+    end
   end
 
-  it "computes the sum of an array of two numbers" do
-    expect(sum([7, 11])).to eq(18)
+  # Extra Credit Test-Driving Bonus:
+  # once the above tests pass,
+  # write tests and code for the following:
+
+  describe "#multiply" do
+    it "multiplies two numbers"
+    it "multiplies several numbers"
   end
 
-  it "computes the sum of an array of many numbers" do
-    expect(sum([1, 3, 5, 7, 9])).to eq(25)
+  describe "#power" do
+    it "raises one number to the power of another number"
   end
-end
 
-# Extra Credit Test-Driving Bonus:
-# once the above tests pass,
-# write tests and code for the following:
-
-describe "#multiply" do
-  it "multiplies two numbers"
-  it "multiplies several numbers"
-end
-
-describe "#power" do
-  it "raises one number to the power of another number"
-end
-
-# http://en.wikipedia.org/wiki/Factorial
-describe "#factorial" do
-  it "computes the factorial of 0"
-  it "computes the factorial of 1"
-  it "computes the factorial of 2"
-  it "computes the factorial of 5"
-  it "computes the factorial of 10"
+  # http://en.wikipedia.org/wiki/Factorial
+  describe "#factorial" do
+    it "computes the factorial of 0"
+    it "computes the factorial of 1"
+    it "computes the factorial of 2"
+    it "computes the factorial of 5"
+    it "computes the factorial of 10"
+  end
 end

--- a/spec/03_simon_says_spec.rb
+++ b/spec/03_simon_says_spec.rb
@@ -13,8 +13,8 @@
 
 require "03_simon_says"
 
-describe "Simon says" do
-  describe "echo" do
+describe "Simon Says" do
+  describe "#echo" do
     it "should echo hello" do
       expect(echo("hello")).to eq("hello")
     end
@@ -24,7 +24,7 @@ describe "Simon says" do
     end
   end
 
-  describe "shout" do
+  describe "#shout" do
     it "should shout hello" do
       expect(shout("hello")).to eq("HELLO")
     end
@@ -34,7 +34,7 @@ describe "Simon says" do
     end
   end
 
-  describe "repeat" do
+  describe "#repeat" do
     it "should repeat" do
       expect(repeat("hello")).to eq("hello hello")
     end
@@ -48,7 +48,7 @@ describe "Simon says" do
     end
   end
 
-  describe "start_of_word" do
+  describe "#start_of_word" do
     it "returns the first letter" do
       expect(start_of_word("hello", 1)).to eq("h")
     end
@@ -65,7 +65,7 @@ describe "Simon says" do
     end
   end
 
-  describe "first_word" do
+  describe "#first_word" do
     it "tells us the first word of 'Hello World' is 'Hello'" do
       expect(first_word("Hello World")).to eq("Hello")
     end
@@ -75,7 +75,7 @@ describe "Simon says" do
     end
   end
 
-  describe "titleize" do
+  describe "#titleize" do
     it "capitalizes a word" do
       expect(titleize("jaws")).to eq("Jaws")
     end

--- a/spec/04_pig_latin_spec.rb
+++ b/spec/04_pig_latin_spec.rb
@@ -23,52 +23,54 @@
 
 require "04_pig_latin"
 
-describe "#translate" do
-  it "translates a word beginning with a vowel" do
-    s = translate("apple")
-    expect(s).to eq("appleay")
-  end
+describe "Pig Latin" do
+  describe "#translate" do
+    it "translates a word beginning with a vowel" do
+      s = translate("apple")
+      expect(s).to eq("appleay")
+    end
 
-  it "translates a word beginning with a consonant" do
-    s = translate("banana")
-    expect(s).to eq("ananabay")
-  end
+    it "translates a word beginning with a consonant" do
+      s = translate("banana")
+      expect(s).to eq("ananabay")
+    end
 
-  it "translates a word beginning with two consonants" do
-    s = translate("cherry")
-    expect(s).to eq("errychay")
-  end
+    it "translates a word beginning with two consonants" do
+      s = translate("cherry")
+      expect(s).to eq("errychay")
+    end
 
-  it "translates two words" do
-    s = translate("eat pie")
-    expect(s).to eq("eatay iepay")
-  end
+    it "translates two words" do
+      s = translate("eat pie")
+      expect(s).to eq("eatay iepay")
+    end
 
-  it "translates a word beginning with three consonants" do
-    expect(translate("three")).to eq("eethray")
-  end
+    it "translates a word beginning with three consonants" do
+      expect(translate("three")).to eq("eethray")
+    end
 
-  it "counts 'sch' as a single phoneme" do
-    s = translate("school")
-    expect(s).to eq("oolschay")
-  end
+    it "counts 'sch' as a single phoneme" do
+      s = translate("school")
+      expect(s).to eq("oolschay")
+    end
 
-  it "counts 'qu' as a single phoneme" do
-    s = translate("quiet")
-    expect(s).to eq("ietquay")
-  end
+    it "counts 'qu' as a single phoneme" do
+      s = translate("quiet")
+      expect(s).to eq("ietquay")
+    end
 
-  it "counts 'qu' as a consonant even when it's preceded by a consonant" do
-    s = translate("square")
-    expect(s).to eq("aresquay")
-  end
+    it "counts 'qu' as a consonant even when it's preceded by a consonant" do
+      s = translate("square")
+      expect(s).to eq("aresquay")
+    end
 
-  it "translates many words" do
-    s = translate("the quick brown fox")
-    expect(s).to eq("ethay ickquay ownbray oxfay")
-  end
+    it "translates many words" do
+      s = translate("the quick brown fox")
+      expect(s).to eq("ethay ickquay ownbray oxfay")
+    end
 
-  # Test-driving bonus:
-  # * write a test asserting that capitalized words are still capitalized (but with a different initial capital letter, of course)
-  # * retain the punctuation from the original phrase
+    # Test-driving bonus:
+    # * write a test asserting that capitalized words are still capitalized (but with a different initial capital letter, of course)
+    # * retain the punctuation from the original phrase
+  end
 end

--- a/spec/05_silly_blocks_spec.rb
+++ b/spec/05_silly_blocks_spec.rb
@@ -7,8 +7,8 @@
 
 require "05_silly_blocks"
 
-describe "some silly block functions" do
-  describe "reverser" do
+describe "Silly Blocks" do
+  describe "#reverser" do
     it "reverses the string returned by the default block" do
       result = reverser do
         "hello"
@@ -26,7 +26,7 @@ describe "some silly block functions" do
     end
   end
 
-  describe "adder" do
+  describe "#adder" do
     it "adds one to the value returned by the default block" do
       expect(adder { 5 }).to eq(6)
     end
@@ -36,7 +36,7 @@ describe "some silly block functions" do
     end
   end
 
-  describe "repeater" do
+  describe "#repeater" do
     it "executes the default block" do
       block_was_executed = false
 

--- a/spec/06_performance_monitor_spec.rb
+++ b/spec/06_performance_monitor_spec.rb
@@ -19,67 +19,69 @@ describe "Performance Monitor" do
     @eleven_am = Time.parse("2011-1-2 11:00:00")
   end
 
-  it "takes about 0 seconds to run an empty block" do
-    elapsed_time = measure { }
+  describe "#measure" do
+    it "takes about 0 seconds to run an empty block" do
+      elapsed_time = measure { }
 
-    expect(elapsed_time).to be_within(0.1).of(0)
-  end
-
-  it "takes exactly 0 seconds to run an empty block (with stubs)" do
-    allow(Time).to receive(:now).and_return(@eleven_am)
-
-    elapsed_time = measure { }
-
-    expect(elapsed_time).to eq(0)
-  end
-
-  it "takes about 1 second to run a block that sleeps for 1 second" do
-    elapsed_time = measure { sleep 1 }
-
-    expect(elapsed_time).to be_within(0.1).of(1)
-  end
-
-  it "takes exactly 1 second to run a block that sleeps for 1 second (with stubs)" do
-    fake_time = @eleven_am
-    allow(Time).to receive(:now) { fake_time }
-
-    elapsed_time = measure do
-      fake_time += 60  # adds one minute to fake_time
+      expect(elapsed_time).to be_within(0.1).of(0)
     end
 
-    expect(elapsed_time).to eq(60)
-  end
+    it "takes exactly 0 seconds to run an empty block (with stubs)" do
+      allow(Time).to receive(:now).and_return(@eleven_am)
 
-  it "runs a block N times" do
-    n = 0
+      elapsed_time = measure { }
 
-    measure(4) { n += 1 }
-
-    expect(n).to eq(4)
-  end
-
-  it "returns the average time, not the total time, when running multiple times" do
-    run_times = [8,6,5,7]
-    fake_time = @eleven_am
-    allow(Time).to receive(:now) { fake_time }
-
-    average_time = measure(4) do
-      fake_time += run_times.pop
+      expect(elapsed_time).to eq(0)
     end
 
-    expect(average_time).to eq(6.5)
-  end
+    it "takes about 1 second to run a block that sleeps for 1 second" do
+      elapsed_time = measure { sleep 1 }
 
-  it "returns the average time when running a random number of times for random lengths of time" do
-    fake_time = @eleven_am
-    allow(Time).to receive(:now) { fake_time }
-    number_of_times = rand(10) + 2
-
-    average_time = measure(number_of_times) do
-      delay = rand(10)
-      fake_time += delay
+      expect(elapsed_time).to be_within(0.1).of(1)
     end
 
-    expect(average_time).to eq((fake_time - @eleven_am).to_f/number_of_times)
+    it "takes exactly 1 second to run a block that sleeps for 1 second (with stubs)" do
+      fake_time = @eleven_am
+      allow(Time).to receive(:now) { fake_time }
+
+      elapsed_time = measure do
+        fake_time += 60  # adds one minute to fake_time
+      end
+
+      expect(elapsed_time).to eq(60)
+    end
+
+    it "runs a block N times" do
+      n = 0
+
+      measure(4) { n += 1 }
+
+      expect(n).to eq(4)
+    end
+
+    it "returns the average time, not the total time, when running multiple times" do
+      run_times = [8,6,5,7]
+      fake_time = @eleven_am
+      allow(Time).to receive(:now) { fake_time }
+
+      average_time = measure(4) do
+        fake_time += run_times.pop
+      end
+
+      expect(average_time).to eq(6.5)
+    end
+
+    it "returns the average time when running a random number of times for random lengths of time" do
+      fake_time = @eleven_am
+      allow(Time).to receive(:now) { fake_time }
+      number_of_times = rand(10) + 2
+
+      average_time = measure(number_of_times) do
+        delay = rand(10)
+        fake_time += delay
+      end
+
+      expect(average_time).to eq((fake_time - @eleven_am).to_f/number_of_times)
+    end
   end
 end

--- a/spec/07_hello_friend_spec.rb
+++ b/spec/07_hello_friend_spec.rb
@@ -97,11 +97,13 @@
 require "07_hello_friend"
 
 describe Friend do
-  it "says hello" do
-    expect(Friend.new.greeting).to eq("Hello!")
-  end
+  describe "#greeting" do
+    it "says hello" do
+      expect(Friend.new.greeting).to eq("Hello!")
+    end
 
-  it "says hello to someone" do
-    expect(Friend.new.greeting("Bob")).to eq("Hello, Bob!")
+    it "says hello to someone" do
+      expect(Friend.new.greeting("Bob")).to eq("Hello, Bob!")
+    end
   end
 end

--- a/spec/08_book_titles_spec.rb
+++ b/spec/08_book_titles_spec.rb
@@ -20,7 +20,7 @@ describe Book do
     @book = Book.new
   end
 
-  describe "title" do
+  describe "#title" do
     it "should capitalize the first letter" do
       @book.title = "inferno"
       expect(@book.title).to eq("Inferno")

--- a/spec/09_timer_spec.rb
+++ b/spec/09_timer_spec.rb
@@ -14,11 +14,13 @@ describe "Timer" do
     @timer = Timer.new
   end
 
-  it "should initialize to 0 seconds" do
-    expect(@timer.seconds).to eq(0)
+  describe "Class" do
+    it "should initialize to 0 seconds" do
+      expect(@timer.seconds).to eq(0)
+    end
   end
 
-  describe "time_string" do
+  describe "#time_string" do
     it "should display 0 seconds as 00:00:00" do
       @timer.seconds = 0
       expect(@timer.time_string).to eq("00:00:00")

--- a/spec/10_temperature_object_spec.rb
+++ b/spec/10_temperature_object_spec.rb
@@ -21,51 +21,53 @@
 require "10_temperature_object"
 
 describe Temperature do
-  describe "can be constructed with an options hash" do
-    describe "in degrees fahrenheit" do
-      it "at 50 degrees" do
-        expect(Temperature.new(:f => 50).in_fahrenheit).to eq(50)
+  describe "Class" do
+    describe "can be constructed with an options hash" do
+      describe "in degrees fahrenheit" do
+        it "at 50 degrees" do
+          expect(Temperature.new(:f => 50).in_fahrenheit).to eq(50)
+        end
+
+        describe "and correctly convert to celsius" do
+          it "at freezing" do
+            expect(Temperature.new(:f => 32).in_celsius).to eq(0)
+          end
+
+          it "at boiling" do
+            expect(Temperature.new(:f => 212).in_celsius).to eq(100)
+          end
+
+          it "at body temperature" do
+            expect(Temperature.new(:f => 98.6).in_celsius).to eq(37)
+          end
+
+          it "at an arbitrary temperature" do
+            expect(Temperature.new(:f => 68).in_celsius).to eq(20)
+          end
+        end
       end
 
-      describe "and correctly convert to celsius" do
-        it "at freezing" do
-          expect(Temperature.new(:f => 32).in_celsius).to eq(0)
+      describe "in degrees celsius" do
+        it "at 50 degrees" do
+          expect(Temperature.new(:c => 50).in_celsius).to eq(50)
         end
 
-        it "at boiling" do
-          expect(Temperature.new(:f => 212).in_celsius).to eq(100)
-        end
+        describe "and correctly convert to fahrenheit" do
+          it "at freezing" do
+            expect(Temperature.new(:c => 0).in_fahrenheit).to eq(32)
+          end
 
-        it "at body temperature" do
-          expect(Temperature.new(:f => 98.6).in_celsius).to eq(37)
-        end
+          it "at boiling" do
+            expect(Temperature.new(:c => 100).in_fahrenheit).to eq(212)
+          end
 
-        it "at an arbitrary temperature" do
-          expect(Temperature.new(:f => 68).in_celsius).to eq(20)
-        end
-      end
-    end
-
-    describe "in degrees celsius" do
-      it "at 50 degrees" do
-        expect(Temperature.new(:c => 50).in_celsius).to eq(50)
-      end
-
-      describe "and correctly convert to fahrenheit" do
-        it "at freezing" do
-          expect(Temperature.new(:c => 0).in_fahrenheit).to eq(32)
-        end
-
-        it "at boiling" do
-          expect(Temperature.new(:c => 100).in_fahrenheit).to eq(212)
-        end
-
-        it "at body temperature" do
-          expect(Temperature.new(:c => 37).in_fahrenheit).to be_within(0.1).of(98.6)
-          # Why do we need to use be_within here?
-          # See http://www.ruby-forum.com/topic/169330
-          # and http://groups.google.com/group/rspec/browse_thread/thread/f3ebbe3c313202bb
-          # Also, try "puts 0.5 - 0.4 - 0.1" -- pretty crazy, right?
+          it "at body temperature" do
+            expect(Temperature.new(:c => 37).in_fahrenheit).to be_within(0.1).of(98.6)
+            # Why do we need to use be_within here?
+            # See http://www.ruby-forum.com/topic/169330
+            # and http://groups.google.com/group/rspec/browse_thread/thread/f3ebbe3c313202bb
+            # Also, try "puts 0.5 - 0.4 - 0.1" -- pretty crazy, right?
+          end
         end
       end
     end

--- a/spec/11_dictionary_spec.rb
+++ b/spec/11_dictionary_spec.rb
@@ -12,71 +12,83 @@ describe Dictionary do
     @d = Dictionary.new
   end
 
-  it "is empty when created" do
-    expect(@d.entries).to eq({})
+  describe "#entries" do
+    it "is empty when created" do
+      expect(@d.entries).to eq({})
+    end
   end
 
-  it "can add whole entries with keyword and definition" do
-    @d.add("fish" => "aquatic animal")
-    expect(@d.entries).to eq({"fish" => "aquatic animal"})
-    expect(@d.keywords).to eq(["fish"])
+  describe "#add" do
+    it "can add whole entries with keyword and definition" do
+      @d.add("fish" => "aquatic animal")
+      expect(@d.entries).to eq({"fish" => "aquatic animal"})
+      expect(@d.keywords).to eq(["fish"])
+    end
+
+    it "add keywords (without definition)" do
+      @d.add("fish")
+      expect(@d.entries).to eq({"fish" => nil})
+      expect(@d.keywords).to eq(["fish"])
+    end
   end
 
-  it "add keywords (without definition)" do
-    @d.add("fish")
-    expect(@d.entries).to eq({"fish" => nil})
-    expect(@d.keywords).to eq(["fish"])
+  describe "#include" do
+    it "can check whether a given keyword exists" do
+      expect(@d.include?("fish")).to be_falsey
+    end
+
+    it "doesn't cheat when checking whether a given keyword exists" do
+      expect(@d.include?("fish")).to be_falsey # if the method is empty, this test passes with nil returned
+      @d.add("fish")
+      expect(@d.include?("fish")).to be_truthy # confirms that it actually checks
+      expect(@d.include?("bird")).to be_falsey # confirms not always returning true after add
+    end
+
+    it "doesn't include a prefix that wasn't added as a word in and of itself" do
+      @d.add("fish")
+      expect(@d.include?("fi")).to be_falsey
+    end
   end
 
-  it "can check whether a given keyword exists" do
-    expect(@d.include?("fish")).to be_falsey
+  describe "#find" do
+    it "doesn't find a word in empty dictionary" do
+      expect(@d.find("fi")).to be_empty # {}
+    end
+
+    it "finds nothing if the prefix matches nothing" do
+      @d.add("fiend")
+      @d.add("great")
+      expect(@d.find("nothing")).to be_empty
+    end
+
+    it "finds an entry" do
+      @d.add("fish" => "aquatic animal")
+      expect(@d.find("fish")).to eq({"fish" => "aquatic animal"})
+    end
+
+    it "finds multiple matches from a prefix and returns the entire entry (keyword + definition)" do
+      @d.add("fish" => "aquatic animal")
+      @d.add("fiend" => "wicked person")
+      @d.add("great" => "remarkable")
+      expect(@d.find("fi")).to eq({"fish" => "aquatic animal", "fiend" => "wicked person"})
+    end
   end
 
-  it "doesn't cheat when checking whether a given keyword exists" do
-    expect(@d.include?("fish")).to be_falsey # if the method is empty, this test passes with nil returned
-    @d.add("fish")
-    expect(@d.include?("fish")).to be_truthy # confirms that it actually checks
-    expect(@d.include?("bird")).to be_falsey # confirms not always returning true after add
+  describe "#keywords" do
+    it "lists keywords alphabetically" do
+      @d.add("zebra" => "African land animal with stripes")
+      @d.add("fish" => "aquatic animal")
+      @d.add("apple" => "fruit")
+      expect(@d.keywords).to eq(%w(apple fish zebra))
+    end
   end
 
-  it "doesn't include a prefix that wasn't added as a word in and of itself" do
-    @d.add("fish")
-    expect(@d.include?("fi")).to be_falsey
-  end
-
-  it "doesn't find a word in empty dictionary" do
-    expect(@d.find("fi")).to be_empty # {}
-  end
-
-  it "finds nothing if the prefix matches nothing" do
-    @d.add("fiend")
-    @d.add("great")
-    expect(@d.find("nothing")).to be_empty
-  end
-
-  it "finds an entry" do
-    @d.add("fish" => "aquatic animal")
-    expect(@d.find("fish")).to eq({"fish" => "aquatic animal"})
-  end
-
-  it "finds multiple matches from a prefix and returns the entire entry (keyword + definition)" do
-    @d.add("fish" => "aquatic animal")
-    @d.add("fiend" => "wicked person")
-    @d.add("great" => "remarkable")
-    expect(@d.find("fi")).to eq({"fish" => "aquatic animal", "fiend" => "wicked person"})
-  end
-
-  it "lists keywords alphabetically" do
-    @d.add("zebra" => "African land animal with stripes")
-    @d.add("fish" => "aquatic animal")
-    @d.add("apple" => "fruit")
-    expect(@d.keywords).to eq(%w(apple fish zebra))
-  end
-
-  it "can produce printable output like so: [keyword] 'definition'" do
-    @d.add("zebra" => "African land animal with stripes")
-    @d.add("fish" => "aquatic animal")
-    @d.add("apple" => "fruit")
-    expect(@d.printable).to eq(%Q{[apple] "fruit"\n[fish] "aquatic animal"\n[zebra] "African land animal with stripes"})
+  describe "#printable" do
+    it "can produce printable output like so: [keyword] 'definition'" do
+      @d.add("zebra" => "African land animal with stripes")
+      @d.add("fish" => "aquatic animal")
+      @d.add("apple" => "fruit")
+      expect(@d.printable).to eq(%Q{[apple] "fruit"\n[fish] "aquatic animal"\n[zebra] "African land animal with stripes"})
+    end
   end
 end

--- a/spec/12_rpn_calculator_spec.rb
+++ b/spec/12_rpn_calculator_spec.rb
@@ -51,110 +51,120 @@ describe RPNCalculator do
     @calculator = RPNCalculator.new
   end
 
-  it "adds two numbers" do
-    calculator.push(2)
-    calculator.push(3)
-    calculator.plus
-    expect(calculator.value).to eq(5)
-  end
-
-  it "adds three numbers" do
-    calculator.push(2)
-    calculator.push(3)
-    calculator.push(4)
-    calculator.plus
-    expect(calculator.value).to eq(7)
-    calculator.plus
-    expect(calculator.value).to eq(9)
-  end
-
-  it "subtracts the second number from the first number" do
-    calculator.push(2)
-    calculator.push(3)
-    calculator.minus
-    expect(calculator.value).to eq(-1)
-  end
-
-  it "adds and subtracts" do
-    calculator.push(2)
-    calculator.push(3)
-    calculator.push(4)
-    calculator.minus
-    expect(calculator.value).to eq(-1)
-    calculator.plus
-    expect(calculator.value).to eq(1)
-  end
-
-  it "multiplies and divides" do
-    calculator.push(2)
-    calculator.push(3)
-    calculator.push(4)
-    calculator.divide
-    expect(calculator.value).to eq((3.0 / 4.0))
-    calculator.times
-    expect(calculator.value).to eq(2.0 * (3.0 / 4.0))
-  end
-
-  it "resolves operator precedence unambiguously" do
-    # 1 2 + 3 * => (1 + 2) * 3
-    calculator.push(1)
-    calculator.push(2)
-    calculator.plus
-    calculator.push(3)
-    calculator.times
-    expect(calculator.value).to eq((1+2)*3)
-
-    @calculator = RPNCalculator.new
-    # 1 2 3 * + => 1 + (2 * 3)
-    calculator.push(1)
-    calculator.push(2)
-    calculator.push(3)
-    calculator.times
-    calculator.plus
-    expect(calculator.value).to eq(1+(2*3))
-  end
-
-  it "fails informatively when there's not enough values stacked away" do
-    expect {
+  describe "#plus" do
+    it "adds two numbers" do
+      calculator.push(2)
+      calculator.push(3)
       calculator.plus
-    }.to raise_error("calculator is empty")
+      expect(calculator.value).to eq(5)
+    end
 
-    expect {
+    it "adds three numbers" do
+      calculator.push(2)
+      calculator.push(3)
+      calculator.push(4)
+      calculator.plus
+      expect(calculator.value).to eq(7)
+      calculator.plus
+      expect(calculator.value).to eq(9)
+    end
+  end
+
+  describe "#minus" do
+    it "subtracts the second number from the first number" do
+      calculator.push(2)
+      calculator.push(3)
       calculator.minus
-    }.to raise_error("calculator is empty")
+      expect(calculator.value).to eq(-1)
+    end
+  end
 
-    expect {
-      calculator.times
-    }.to raise_error("calculator is empty")
+  describe "system" do
+    it "adds and subtracts" do
+      calculator.push(2)
+      calculator.push(3)
+      calculator.push(4)
+      calculator.minus
+      expect(calculator.value).to eq(-1)
+      calculator.plus
+      expect(calculator.value).to eq(1)
+    end
 
-    expect {
+    it "multiplies and divides" do
+      calculator.push(2)
+      calculator.push(3)
+      calculator.push(4)
       calculator.divide
-    }.to raise_error("calculator is empty")
+      expect(calculator.value).to eq((3.0 / 4.0))
+      calculator.times
+      expect(calculator.value).to eq(2.0 * (3.0 / 4.0))
+    end
+
+    it "resolves operator precedence unambiguously" do
+      # 1 2 + 3 * => (1 + 2) * 3
+      calculator.push(1)
+      calculator.push(2)
+      calculator.plus
+      calculator.push(3)
+      calculator.times
+      expect(calculator.value).to eq((1+2)*3)
+
+      @calculator = RPNCalculator.new
+      # 1 2 3 * + => 1 + (2 * 3)
+      calculator.push(1)
+      calculator.push(2)
+      calculator.push(3)
+      calculator.times
+      calculator.plus
+      expect(calculator.value).to eq(1+(2*3))
+    end
+
+    it "fails informatively when there's not enough values stacked away" do
+      expect {
+        calculator.plus
+      }.to raise_error("calculator is empty")
+
+      expect {
+        calculator.minus
+      }.to raise_error("calculator is empty")
+
+      expect {
+        calculator.times
+      }.to raise_error("calculator is empty")
+
+      expect {
+        calculator.divide
+      }.to raise_error("calculator is empty")
+    end
   end
 
-  # extra credit
-  it "tokenizes a string" do
-    expect(calculator.tokens("1 2 3 * + 4 5 - /")).to eq(
-      [1, 2, 3, :*, :+, 4, 5, :-, :/]
-    )
+  describe "#tokens" do
+    # extra credit
+    it "tokenizes a string" do
+      expect(calculator.tokens("1 2 3 * + 4 5 - /")).to eq(
+        [1, 2, 3, :*, :+, 4, 5, :-, :/]
+      )
+    end
   end
 
-  # extra credit
-  it "evaluates a string" do
-    expect(calculator.evaluate("1 2 3 * +")).to eq(
-      ((2 * 3) + 1)
-    )
+  describe "#evaluate" do
+    # extra credit
+    it "evaluates a string" do
+      expect(calculator.evaluate("1 2 3 * +")).to eq(
+        ((2 * 3) + 1)
+      )
 
-    expect(calculator.evaluate("4 5 -")).to eq(
-      (4 - 5)
-    )
+      expect(calculator.evaluate("4 5 -")).to eq(
+        (4 - 5)
+      )
 
-    expect(calculator.evaluate("2 3 /")).to eq(
-      (2.0 / 3.0)
-    )
+      expect(calculator.evaluate("2 3 /")).to eq(
+        (2.0 / 3.0)
+      )
 
-    expect(calculator.evaluate("1 2 3 * + 4 5 - /")).to eq(
-      (1.0 + (2 * 3)) / (4 - 5)
-    )
+      expect(calculator.evaluate("1 2 3 * + 4 5 - /")).to eq(
+        (1.0 + (2 * 3)) / (4 - 5)
+      )
+    end
   end
 end

--- a/spec/13_xml_document_spec.rb
+++ b/spec/13_xml_document_spec.rb
@@ -23,60 +23,66 @@ describe XmlDocument do
     @xml = XmlDocument.new
   end
 
-  it "renders an empty tag" do
-    expect(@xml.hello).to eq("<hello/>")
-  end
-
-  it "renders a tag with attributes" do
-    expect(@xml.hello(:name => "dolly")).to eq('<hello name="dolly"/>')
-  end
-
-  it "renders a randomly named tag" do
-    tag_name = (1..8).map{|i| ("a".."z").to_a[rand(26)]}.join
-    expect(@xml.send(tag_name)).to eq("<#{tag_name}/>")
-  end
-
-  it "renders block with text inside" do
-    expect(@xml.hello { "dolly" }).to eq("<hello>dolly</hello>")
-  end
-
-  it "nests one level" do
-    expect(@xml.hello { @xml.goodbye }).to eq("<hello><goodbye/></hello>")
-  end
-
-  it "nests several levels" do
-    xml = XmlDocument.new
-
-    xml_string = xml.hello do
-      xml.goodbye do
-        xml.come_back do
-          xml.ok_fine(:be => "that_way")
-        end
-      end
+  describe "#hello" do
+    it "renders an empty tag" do
+      expect(@xml.hello).to eq("<hello/>")
     end
 
-    expect(xml_string).to eq('<hello><goodbye><come_back><ok_fine be="that_way"/></come_back></goodbye></hello>')
-  end
-
-  it "indents" do
-    @xml = XmlDocument.new(true)
-
-    xml_string = @xml.hello do
-      @xml.goodbye do
-        @xml.come_back do
-          @xml.ok_fine(:be => "that_way")
-        end
-      end
+    it "renders a tag with attributes" do
+      expect(@xml.hello(:name => "dolly")).to eq('<hello name="dolly"/>')
     end
 
-    expect(xml_string).to eq(
-      "<hello>\n" +
-      "  <goodbye>\n" +
-      "    <come_back>\n" +
-      "      <ok_fine be=\"that_way\"/>\n" +
-      "    </come_back>\n" +
-      "  </goodbye>\n" +
-      "</hello>\n"
-    )
+    it "renders block with text inside" do
+      expect(@xml.hello { "dolly" }).to eq("<hello>dolly</hello>")
+    end
+
+    it "nests one level" do
+      expect(@xml.hello { @xml.goodbye }).to eq("<hello><goodbye/></hello>")
+    end
+  end
+
+  describe "#send" do
+    it "renders a randomly named tag" do
+      tag_name = (1..8).map{|i| ("a".."z").to_a[rand(26)]}.join
+      expect(@xml.send(tag_name)).to eq("<#{tag_name}/>")
+    end
+  end
+
+  describe "system" do
+    it "nests several levels" do
+      xml = XmlDocument.new
+
+      xml_string = xml.hello do
+        xml.goodbye do
+          xml.come_back do
+            xml.ok_fine(:be => "that_way")
+          end
+        end
+      end
+
+      expect(xml_string).to eq('<hello><goodbye><come_back><ok_fine be="that_way"/></come_back></goodbye></hello>')
+    end
+
+    it "indents" do
+      @xml = XmlDocument.new(true)
+
+      xml_string = @xml.hello do
+        @xml.goodbye do
+          @xml.come_back do
+            @xml.ok_fine(:be => "that_way")
+          end
+        end
+      end
+
+      expect(xml_string).to eq(
+        "<hello>\n" +
+        "  <goodbye>\n" +
+        "    <come_back>\n" +
+        "      <ok_fine be=\"that_way\"/>\n" +
+        "    </come_back>\n" +
+        "  </goodbye>\n" +
+        "</hello>\n"
+      )
+    end
   end
 end

--- a/spec/15_in_words_spec.rb
+++ b/spec/15_in_words_spec.rb
@@ -25,80 +25,82 @@
 require "15_in_words"
 
 describe Fixnum do
-  it "reads 0 to 9" do
-    expect(0.in_words).to eq("zero")
-    expect(1.in_words).to eq("one")
-    expect(2.in_words).to eq("two")
-    expect(3.in_words).to eq("three")
-    expect(4.in_words).to eq("four")
-    expect(5.in_words).to eq("five")
-    expect(6.in_words).to eq("six")
-    expect(7.in_words).to eq("seven")
-    expect(8.in_words).to eq("eight")
-    expect(9.in_words).to eq("nine")
-  end
+  describe "#in_words" do
+    it "reads 0 to 9" do
+      expect(0.in_words).to eq("zero")
+      expect(1.in_words).to eq("one")
+      expect(2.in_words).to eq("two")
+      expect(3.in_words).to eq("three")
+      expect(4.in_words).to eq("four")
+      expect(5.in_words).to eq("five")
+      expect(6.in_words).to eq("six")
+      expect(7.in_words).to eq("seven")
+      expect(8.in_words).to eq("eight")
+      expect(9.in_words).to eq("nine")
+    end
 
-  it "reads 10 to 12" do
-    expect(10.in_words).to eq("ten")
-    expect(11.in_words).to eq("eleven")
-    expect(12.in_words).to eq("twelve")
-  end
+    it "reads 10 to 12" do
+      expect(10.in_words).to eq("ten")
+      expect(11.in_words).to eq("eleven")
+      expect(12.in_words).to eq("twelve")
+    end
 
-  it "reads teens" do
-    expect(13.in_words).to eq("thirteen")
-    expect(14.in_words).to eq("fourteen")
-    expect(15.in_words).to eq("fifteen")
-    expect(16.in_words).to eq("sixteen")
-    expect(17.in_words).to eq("seventeen")
-    expect(18.in_words).to eq("eighteen")
-    expect(19.in_words).to eq("nineteen")
-  end
+    it "reads teens" do
+      expect(13.in_words).to eq("thirteen")
+      expect(14.in_words).to eq("fourteen")
+      expect(15.in_words).to eq("fifteen")
+      expect(16.in_words).to eq("sixteen")
+      expect(17.in_words).to eq("seventeen")
+      expect(18.in_words).to eq("eighteen")
+      expect(19.in_words).to eq("nineteen")
+    end
 
-  it "reads tens" do
-    expect(20.in_words).to eq("twenty")
-    expect(30.in_words).to eq("thirty")
-    expect(40.in_words).to eq("forty")
-    expect(50.in_words).to eq("fifty")
-    expect(60.in_words).to eq("sixty")
-    expect(70.in_words).to eq("seventy")
-    expect(80.in_words).to eq("eighty")
-    expect(90.in_words).to eq("ninety")
-  end
+    it "reads tens" do
+      expect(20.in_words).to eq("twenty")
+      expect(30.in_words).to eq("thirty")
+      expect(40.in_words).to eq("forty")
+      expect(50.in_words).to eq("fifty")
+      expect(60.in_words).to eq("sixty")
+      expect(70.in_words).to eq("seventy")
+      expect(80.in_words).to eq("eighty")
+      expect(90.in_words).to eq("ninety")
+    end
 
-  it "reads various other numbers less than 100" do
-    expect(20.in_words).to eq("twenty")
-    expect(77.in_words).to eq("seventy seven")
-    expect(99.in_words).to eq("ninety nine")
-  end
+    it "reads various other numbers less than 100" do
+      expect(20.in_words).to eq("twenty")
+      expect(77.in_words).to eq("seventy seven")
+      expect(99.in_words).to eq("ninety nine")
+    end
 
-  it "reads hundreds" do
-    expect(100.in_words).to eq("one hundred")
-    expect(200.in_words).to eq("two hundred")
-    expect(300.in_words).to eq("three hundred")
-    expect(123.in_words).to eq("one hundred twenty three")
-    expect(777.in_words).to eq("seven hundred seventy seven")
-    expect(818.in_words).to eq("eight hundred eighteen")
-    expect(512.in_words).to eq("five hundred twelve")
-    expect(999.in_words).to eq("nine hundred ninety nine")
-  end
+    it "reads hundreds" do
+      expect(100.in_words).to eq("one hundred")
+      expect(200.in_words).to eq("two hundred")
+      expect(300.in_words).to eq("three hundred")
+      expect(123.in_words).to eq("one hundred twenty three")
+      expect(777.in_words).to eq("seven hundred seventy seven")
+      expect(818.in_words).to eq("eight hundred eighteen")
+      expect(512.in_words).to eq("five hundred twelve")
+      expect(999.in_words).to eq("nine hundred ninety nine")
+    end
 
-  it "reads thousands" do
-    expect(1000.in_words).to eq("one thousand")
-    expect(32767.in_words).to eq("thirty two thousand seven hundred sixty seven")
-    expect(32768.in_words).to eq("thirty two thousand seven hundred sixty eight")
-  end
+    it "reads thousands" do
+      expect(1000.in_words).to eq("one thousand")
+      expect(32767.in_words).to eq("thirty two thousand seven hundred sixty seven")
+      expect(32768.in_words).to eq("thirty two thousand seven hundred sixty eight")
+    end
 
-  it "reads millions" do
-    expect(10_000_001.in_words).to eq("ten million one")
-  end
+    it "reads millions" do
+      expect(10_000_001.in_words).to eq("ten million one")
+    end
 
-  it "reads billions" do
-    expect(1_234_567_890.in_words).to eq("one billion two hundred thirty four million five hundred sixty seven thousand eight hundred ninety")
-  end
+    it "reads billions" do
+      expect(1_234_567_890.in_words).to eq("one billion two hundred thirty four million five hundred sixty seven thousand eight hundred ninety")
+    end
 
-  it "reads trillions" do
-    expect(1_000_000_000_000.in_words).to eq("one trillion")
-    expect(1_000_000_000_001.in_words).to eq("one trillion one")
-    expect(1_888_259_040_036.in_words).to eq("one trillion eight hundred eighty eight billion two hundred fifty nine million forty thousand thirty six")
+    it "reads trillions" do
+      expect(1_000_000_000_000.in_words).to eq("one trillion")
+      expect(1_000_000_000_001.in_words).to eq("one trillion one")
+      expect(1_888_259_040_036.in_words).to eq("one trillion eight hundred eighty eight billion two hundred fifty nine million forty thousand thirty six")
+    end
   end
 end


### PR DESCRIPTION
Hello, I don't mean to boggle anyone down with technicalities (no breakthroughs here), but I was wondering why the default textual output for the specs seem to lack a bit of consistency. If not for internal evaluation reasons, why not follow some sort of predicable format? Below are before and after images illustrating a possible improvement. 

Before:
![before](https://cloud.githubusercontent.com/assets/1965756/15226411/906dbc72-1850-11e6-8404-c8aeea058ae4.png)

After:
![after](https://cloud.githubusercontent.com/assets/1965756/15226556/325c044e-1851-11e6-8c83-7b5d0e901c98.png)


For now, I've just made a few simple changes:
1. Maybe sure that every spec had a title corresponding to their filename.
2. Made sure that individual "it" blocks where surrounded by their respective method.
3. Made sure that all methods/functions were prefix by a "#" as intended on some of the specs.

I feel that this is important because it shows a clear distinction of where one test starts and another ends, and what subsection it pertains to. This would allow for a quicker analysis.

Unlike the rest, the "10_temperature_object_spec.rb" spec follows a very human-linguist style, so I left it mostly alone until further discussion.