### PR TITLE
Update 03_simon_says_spec.rb

### DIFF
--- a/spec/03_simon_says_spec.rb
+++ b/spec/03_simon_says_spec.rb
@@ -89,7 +89,7 @@ describe "Simon says" do
     end
 
     it "does capitalize 'little words' at the start of a title" do
-      expect(titleize("the bridge over the river kwai")).to eq("The Bridge over the River Kwai")
+      expect(titleize("the bridge over the river kwai")).to eq("The Bridge Over the River Kwai")
     end
   end
 end


### PR DESCRIPTION
I changed line 92's .to eq("The Bridge over the River Kwai") to ==> .to eq("The Bridge Over the River Kwai"), because it seems that 'over' should be capitalized as well, if I am understanding 'little words' to be words that are under three letters?